### PR TITLE
Proper eigen3 dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
     <build_depend>cmake_modules</build_depend>
     <build_depend>costmap_2d</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
-    <build_depend>Eigen3</build_depend>
+    <build_depend>eigen3</build_depend>
     <build_depend>nav_core</build_depend>
     <build_depend>nav_msgs</build_depend>
     <build_depend>pluginlib</build_depend>
@@ -21,7 +21,7 @@
 
     <run_depend>costmap_2d</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
-    <run_depend>Eigen3</run_depend>
+    <run_depend>eigen3</run_depend>
     <run_depend>nav_core</run_depend>
     <run_depend>nav_msgs</run_depend>
     <run_depend>pluginlib</run_depend>


### PR DESCRIPTION
Eigen3 is not a ROS dependency in the base.yaml (https://github.com/ros/rosdistro/blob/1a9fda299e71f1b0dbe670516420fb05986b7214/rosdep/base.yaml#L667)